### PR TITLE
fix: compatible with new pycasbin

### DIFF
--- a/casbin_adapter/enforcer.py
+++ b/casbin_adapter/enforcer.py
@@ -31,7 +31,7 @@ class ProxyEnforcer(Enforcer):
             Adapter = import_class(adapter_loc)
             adapter = Adapter(*adapter_args)
 
-            super().__init__(model, adapter, enable_log)
+            super().__init__(model, adapter)
             logger.debug("Casbin enforcer initialised")
 
             watcher = getattr(settings, "CASBIN_WATCHER", None)


### PR DESCRIPTION
Fix: https://github.com/pycasbin/django-orm-adapter/issues/14